### PR TITLE
Use Node.js v10 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nodered/node-red-docker
+FROM nodered/node-red-docker:v10
 
 RUN npm install node-red-contrib-model-asset-exchange@0.2.5 node-red-contrib-browser-utils node-red-contrib-image-output
 


### PR DESCRIPTION
Upgrading to Node.js v10 Node-RED base image. No problems were found during testing.